### PR TITLE
fix(schema/events/connector): id is any string

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ const event: EventOptions<"connector"> = {
     createdAt: Date.now()
   },
   data: {
-    id: 1,
+    id: "1",
     code: "JFAC"
   }
 };

--- a/src/schema/events/connector.json
+++ b/src/schema/events/connector.json
@@ -4,8 +4,7 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string",
-          "pattern": "^[0-9]+"
+          "type": "string"
         },
         "code": {
           "type": "string"
@@ -22,8 +21,7 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string",
-          "pattern": "^[0-9]+"
+          "type": "string"
         },
         "code": {
           "type": "string"
@@ -40,8 +38,7 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string",
-          "pattern": "^[0-9]+"
+          "type": "string"
         },
         "code": {
           "type": "string"

--- a/test/UT/index.test.ts
+++ b/test/UT/index.test.ts
@@ -54,22 +54,6 @@ describe("validate", () => {
     });
   });
 
-  test("Given a wrong property, it should throw", () => {
-    const event = {
-      name: "connector",
-      operation: "CREATE",
-      data: {
-        id: "foo",
-        code: "bar"
-      }
-    };
-
-    assert.throws(() => validate(event as any), {
-      name: "Error",
-      message: `data: [/id: must match pattern \"^[0-9]+\"]`
-    });
-  });
-
   test("Given a wrong metadata, it should throw", () => {
     const event = {
       name: "accountingFolder",


### PR DESCRIPTION
FirmConnector utilise un UUID en ID donc je retire le pattern sur l'id.
On pourrait aussi créer un nouvel event mais pas sur que ce soit nécesssaire, le scope de l'event permet de faire la différence (pas d'accountingFolderId si c'est du firmConnector)